### PR TITLE
Fix ROS2 C++ build with proper ament CMake exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ endif()
 
 project(${LIB_TARGET} LANGUAGES CXX VERSION 0.0.1)
 
+if (NOT DEFINED LF_REACTOR_CPP_SUFFIX)
+  find_package(ament_cmake QUIET)
+  if(ament_cmake_FOUND)
+    set(REACTOR_CPP_USE_AMENT ON)
+  endif()
+endif()
+
 # require C++17
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -70,4 +77,18 @@ if (DEFINED LF_REACTOR_CPP_SUFFIX)
   install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIB_TARGET}")
 else()
   install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+
+if (REACTOR_CPP_USE_AMENT)
+  # Install the export file - must be in root CMakeLists.txt for ament compatibility
+  install(EXPORT ${LIB_TARGET} DESTINATION share/${LIB_TARGET}/cmake NAMESPACE ${LIB_TARGET}::)
+  ament_export_targets(${LIB_TARGET} HAS_LIBRARY_TARGET)
+  ament_export_include_directories(include)
+  ament_export_libraries(${LIB_TARGET})
+  ament_package()
+else()
+  # For non-ament builds, install export file from here
+  if(REACTOR_CPP_INSTALL)
+    install(EXPORT ${LIB_TARGET} DESTINATION share/${LIB_TARGET}/cmake)
+  endif()
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,12 +61,9 @@ if(REACTOR_CPP_INSTALL)
     install(FILES "${PROJECT_BINARY_DIR}/include/reactor-cpp/config.hh" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/reactor-cpp")
   endif()
 
-  install(TARGETS ${LIB_TARGET} EXPORT ${LIB_TARGET}Config
+  install(TARGETS ${LIB_TARGET} EXPORT ${LIB_TARGET}
       ARCHIVE  DESTINATION "${CMAKE_INSTALL_LIBDIR}" OPTIONAL
       LIBRARY  DESTINATION "${CMAKE_INSTALL_LIBDIR}" OPTIONAL
       RUNTIME  DESTINATION "${CMAKE_INSTALL_BINDIR}" OPTIONAL)
-
-  install(EXPORT ${LIB_TARGET}Config DESTINATION share/${LIB_TARGET}/cmake)
-
-  export(TARGETS ${PROJECT_NAME} FILE ${LIB_TARGET}Config.cmake)
+  # Note: install(EXPORT ...) moved to root CMakeLists.txt for ament compatibility
 endif()

--- a/package.xml
+++ b/package.xml
@@ -6,17 +6,8 @@
  <description>A C++ reactor runtime</description>
  <maintainer email="christian.menard@tu-dresden.de">user</maintainer>
  <license>ISC License</license>
+ <buildtool_depend>ament_cmake</buildtool_depend>
  <export>
-   <build_type>cmake</build_type>
- </export>
-</package>
-<package format="3">
- <name>reactor-cpp-foo</name>
- <version>0.0.0</version>
- <description>A C++ reactor runtime</description>
- <maintainer email="christian.menard@tu-dresden.de">user</maintainer>
- <license>ISC License</license>
- <export>
-   <build_type>cmake</build_type>
+   <build_type>ament_cmake</build_type>
  </export>
 </package>


### PR DESCRIPTION
## Summary

Fixes the ROS2 C++ build integration by correcting how reactor-cpp exports its CMake configuration for the ament/colcon ecosystem.

## Problem

When building LF programs with the ROS2 platform, downstream packages could not find the `reactor-cpp` library via CMake's `find_package(reactor-cpp REQUIRED)`.

**Root cause:** The reactor-cpp library was being built and installed correctly by colcon, but its CMake export configuration wasn't set up properly for the ament/colcon ecosystem:

- The `install(EXPORT ...)` command was in `lib/CMakeLists.txt`, but ament requires it to be in the root `CMakeLists.txt` alongside `ament_package()` for proper integration
- The export lacked a `NAMESPACE`, which meant the generated CMake config file didn't create proper imported targets

## Changes

1. **Added ament detection** - Detect when building in a colcon/ament environment and set `REACTOR_CPP_USE_AMENT`

2. **Moved export installation to root CMakeLists.txt** - For ament compatibility, the `install(EXPORT ...)` must be in the same file as `ament_package()`

3. **Added NAMESPACE to exports** - Use `NAMESPACE ${LIB_TARGET}::` so downstream packages can link via `reactor-cpp::reactor-cpp`

4. **Added proper ament exports:**
   ```cmake
   ament_export_targets(${LIB_TARGET} HAS_LIBRARY_TARGET)
   ament_export_include_directories(include)
   ament_export_libraries(${LIB_TARGET})
   ament_package()
   ```

## Related PR

- lf-lang/lingua-franca#2580

🤖 Generated with [Claude Code](https://claude.ai/code)